### PR TITLE
fix for pin numbers 8-15

### DIFF
--- a/KBD/kbd.h
+++ b/KBD/kbd.h
@@ -54,7 +54,7 @@ typedef struct {
 			uint8_t debounced			: 1;
 		};
 	};
-	uint8_t 	pinmask;
+	uint16_t 	pinmask;
 	uint16_t	counter;
 	char		status;
 #if KBDCALLBACKENABLED == 1


### PR DESCRIPTION
Stm32 port has 16 pins, so pinmask should be 16 bit length to be able to set any of 16 pins.